### PR TITLE
change default locale to US to prevent localization issues

### DIFF
--- a/src/main/kotlin/de/jagenka/Util.kt
+++ b/src/main/kotlin/de/jagenka/Util.kt
@@ -6,7 +6,7 @@ object Util
 {
     fun Double.trimDecimals(digits: Int): String
     {
-        return "%.${digits}f".format(this)
+        return "%.${digits}f".format(Locale.US, this)
     }
 
     fun <T> Optional<T>.unwrap(): T? = orElse(null)


### PR DESCRIPTION
Minecraft seems to use US locale